### PR TITLE
Update graceful shutdown hangs on potential error

### DIFF
--- a/packages/flanc/src/graceful-shutdown.ts
+++ b/packages/flanc/src/graceful-shutdown.ts
@@ -15,6 +15,7 @@ function shutdown(server: AppServer, onShutdown?: (server: AppServer) => any) {
     server.ready = false;
     if (onShutdown) onShutdown(server);
     setTimeout(server.stop, shutdownRoutine.serverClose);
+    setTimeout(process.exit(0), shutdownRoutine.serverClose + 1000);
   }
 }
 


### PR DESCRIPTION
This adds a fail-safe, so that process doesn't hang and not exit on a shutdown error.